### PR TITLE
[http] Work around stateful authentication schemes

### DIFF
--- a/src/net/tcp/httpconn.c
+++ b/src/net/tcp/httpconn.c
@@ -252,8 +252,13 @@ int http_connect ( struct interface *xfer, struct uri *uri ) {
 	/* Identify port */
 	port = uri_port ( uri, scheme->port );
 
-	/* Look for a reusable connection in the pool */
-	list_for_each_entry ( conn, &http_connection_pool, pool.list ) {
+	/* Look for a reusable connection in the pool.  Reuse the most
+	 * recent connection in order to accommodate authentication
+	 * schemes that break the stateless nature of HTTP and rely on
+	 * the same connection being reused for authentication
+	 * responses.
+	 */
+	list_for_each_entry_reverse ( conn, &http_connection_pool, pool.list ) {
 
 		/* Sanity checks */
 		assert ( conn->uri != NULL );


### PR DESCRIPTION
As pointedly documented in RFC7230 section 2.3, HTTP is a stateless
protocol: each request message can be understood in isolation from any
other requests or responses.  Various authentication schemes such as
NTLM break this fundamental property of HTTP and rely on the same TCP
connection being reused.

Work around these broken authentication schemes by ensuring that the
most recently pooled connection is reused for the subsequent
authentication retry.

Reported-by: Andreas Hammarskjöld <junior@2PintSoftware.com>
Tested-by: Andreas Hammarskjöld <junior@2PintSoftware.com>
Signed-off-by: Michael Brown <mcb30@ipxe.org>